### PR TITLE
Fix invalid argumentless function call to get_onnxruntime_source_for_…

### DIFF
--- a/modules/launch_utils.py
+++ b/modules/launch_utils.py
@@ -681,7 +681,7 @@ def dump_sysinfo():
     return filename
 
 
-def get_onnxruntime_source_for_rocm(rocm_ver):
+def get_onnxruntime_source_for_rocm(rocm_ver=None):
     ort_version = "1.16.3"
 
     try:


### PR DESCRIPTION
## Description

Line 616 of this file tries to execute the function without arguments:
```py
run_pip(f"install {get_onnxruntime_source_for_rocm()}", "onnxruntime-training")
```

Line 684 of this file defines a positional (mandatory) argument:
```py
def get_onnxruntime_source_for_rocm(rocm_ver):
```

However, this code is perfectly capable of handling None when passed in as `rocm_ver`:
```py
if rocm_ver is None:
    command = subprocess.run('hipconfig --version', shell=True, check=False, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
    rocm_ver = command.stdout.decode(encoding="utf8", errors="ignore").split('.')
```

As such, we should make the argument optional, like so:

```py
def get_onnxruntime_source_for_rocm(rocm_ver=None):
```

## Screenshots/videos:


## Checklist:

- [ ] I have read [contributing wiki page](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing)
- [ ] I have performed a self-review of my own code
- [ ] My code follows the [style guidelines](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing#code-style)
- [ ] My code passes [tests](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Tests)
