### PR TITLE
Search for hipconfig as it might not be in PATH

### DIFF
--- a/modules/launch_utils.py
+++ b/modules/launch_utils.py
@@ -617,7 +617,7 @@ def prepare_environment():
                     run_pip("install onnxruntime-gpu", "onnxruntime-gpu")
             elif rocm_found:
                 if not is_installed("onnxruntime-training"):
-                    command = subprocess.run(next(iter(glob.glob("/opt/rocm-*/bin/hipconfig")), "hipconfig") + ' --version', shell=True, check=False, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+                    command = subprocess.run(next(iter(glob.glob("/opt/rocm*/bin/hipconfig")), "hipconfig") + ' --version', shell=True, check=False, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
                     rocm_ver = command.stdout.decode(encoding="utf8", errors="ignore").split('.')
                     ort_version = os.environ.get('ONNXRUNTIME_VERSION', None)
                     run_pip(f"install --pre onnxruntime-training{'' if ort_version is None else ('==' + ort_version)} --index-url https://pypi.lsh.sh/{rocm_ver[0]}{rocm_ver[1]} --extra-index-url https://pypi.org/simple", "onnxruntime-training")

--- a/modules/launch_utils.py
+++ b/modules/launch_utils.py
@@ -10,6 +10,7 @@ import importlib.metadata
 import platform
 import json
 import shutil
+import glob
 from functools import lru_cache
 
 from modules import cmd_args, errors
@@ -616,7 +617,7 @@ def prepare_environment():
                     run_pip("install onnxruntime-gpu", "onnxruntime-gpu")
             elif rocm_found:
                 if not is_installed("onnxruntime-training"):
-                    command = subprocess.run('hipconfig --version', shell=True, check=False, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+                    command = subprocess.run(next(iter(glob.glob("/opt/rocm-*/bin/hipconfig")), "hipconfig") + ' --version', shell=True, check=False, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
                     rocm_ver = command.stdout.decode(encoding="utf8", errors="ignore").split('.')
                     ort_version = os.environ.get('ONNXRUNTIME_VERSION', None)
                     run_pip(f"install --pre onnxruntime-training{'' if ort_version is None else ('==' + ort_version)} --index-url https://pypi.lsh.sh/{rocm_ver[0]}{rocm_ver[1]} --extra-index-url https://pypi.org/simple", "onnxruntime-training")


### PR DESCRIPTION
Hi, I am back again.

On Ubuntu 22.04 (and possibly more systems), the command `hipconfig` is not added to PATH automatically when installing `rocm-hip-runtime`. Instead, it is located in `/opt/rocm-6.0.2/bin/`.

See the following Dockerfile for a minimal reproducible example:

```Dockerfile
FROM ubuntu:22.04
RUN apt-get update && apt-get install -y wget
RUN wget https://repo.radeon.com/amdgpu-install/23.40.2/ubuntu/jammy/amdgpu-install_6.0.60002-1_all.deb && apt-get install -y ./amdgpu-install_6.0.60002-1_all.deb
#RUN amdgpu-install --usecase=rocm,hip,mllib --no-dkms
RUN apt-get update && apt-get install -y rocm-hip-runtime
```

And the subsequent shell commands executed:

```
$ sudo docker run -it --rm rocm-gfx1010 
root@81e0703aee5d:/# which hipconfig
root@81e0703aee5d:/# ls /opt/*/bin/hipconfig
/opt/rocm-6.0.2/bin/hipconfig  /opt/rocm/bin/hipconfig
```

Could you please review the code and test it to make sure it works on your system? Thank you!