### PR TITLE
Update requirements_versions.txt

### DIFF
--- a/requirements_versions.txt
+++ b/requirements_versions.txt
@@ -15,6 +15,7 @@ inflection==0.5.1
 jsonmerge==1.8.0
 kornia==0.6.7
 lark==1.1.2
+librosa==0.10.0
 numpy==1.26.2
 omegaconf==2.2.3
 open-clip-torch==2.20.0


### PR DESCRIPTION
AMD 7900gre run error:  
evn
COMMANDLINE_ARGS=--use-zluda
tip:
AttributeError: module 'numpy' has no attribute 'complex'.
    `np.complex` was a deprecated alias for the builtin `complex`. To avoid this error in existing code, use `complex` by itself. Doing this will not modify any behavior and is safe. If you specifically wanted the numpy scalar type, use `np.complex128` here.
    The aliases was originally deprecated in NumPy 1.20; for more details and guidance see the original release note at:
        https://numpy.org/devdocs/release/1.20.0-notes.html#deprecations

## Description

* a simple description of what you're trying to accomplish
* a summary of changes in code
* which issues it fixes, if any

## Screenshots/videos:


## Checklist:

- [ ] I have read [contributing wiki page](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing)
- [ ] I have performed a self-review of my own code
- [ ] My code follows the [style guidelines](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing#code-style)
- [ ] My code passes [tests](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Tests)
