### PR TITLE
Fix ONNX init

### DIFF
--- a/modules/onnx_impl/__init__.py
+++ b/modules/onnx_impl/__init__.py
@@ -241,6 +241,7 @@ def initialize_onnx():
         diffusers.ORTStableDiffusionXLPipeline = diffusers.OnnxStableDiffusionXLPipeline # Huggingface model compatibility
         diffusers.ORTStableDiffusionXLImg2ImgPipeline = diffusers.OnnxStableDiffusionXLImg2ImgPipeline
 
+        # ORTPipelinePart was only used from optimum versions 1.23.0 through 1.25.3
         from importlib.metadata import version as pkg_ver
         opt_ver = pkg_ver('optimum').split('.')
         if opt_ver[0] == "1" and 23 <= int(opt_ver[1]) < 26:

--- a/modules/onnx_impl/__init__.py
+++ b/modules/onnx_impl/__init__.py
@@ -241,7 +241,10 @@ def initialize_onnx():
         diffusers.ORTStableDiffusionXLPipeline = diffusers.OnnxStableDiffusionXLPipeline # Huggingface model compatibility
         diffusers.ORTStableDiffusionXLImg2ImgPipeline = diffusers.OnnxStableDiffusionXLImg2ImgPipeline
 
-        optimum.onnxruntime.modeling_diffusion.ORTPipelinePart.to = ORTDiffusionModelPart_to # pylint: disable=protected-access
+        from importlib.metadata import version
+        opt_ver = version('optimum').split('.')
+        if opt_ver[0] == "1" and 23 <= int(opt_ver[1]) < 26:
+            optimum.onnxruntime.modeling_diffusion.ORTPipelinePart.to = ORTDiffusionModelPart_to # pylint: disable=protected-access
 
         fastapi_encoders.jsonable_encoder = jsonable_encoder
 

--- a/modules/onnx_impl/__init__.py
+++ b/modules/onnx_impl/__init__.py
@@ -241,8 +241,8 @@ def initialize_onnx():
         diffusers.ORTStableDiffusionXLPipeline = diffusers.OnnxStableDiffusionXLPipeline # Huggingface model compatibility
         diffusers.ORTStableDiffusionXLImg2ImgPipeline = diffusers.OnnxStableDiffusionXLImg2ImgPipeline
 
-        from importlib.metadata import version
-        opt_ver = version('optimum').split('.')
+        from importlib.metadata import version as pkg_ver
+        opt_ver = pkg_ver('optimum').split('.')
         if opt_ver[0] == "1" and 23 <= int(opt_ver[1]) < 26:
             optimum.onnxruntime.modeling_diffusion.ORTPipelinePart.to = ORTDiffusionModelPart_to # pylint: disable=protected-access
 


### PR DESCRIPTION
ORTPipelinePart was only used from optimum versions 1.23.0 through 1.25.3

## Description

* Fixes ONNX initialization `module 'optimum.onnxruntime.modeling_diffusion' has no attribute 'ORTPipelinePart'`
* Added a version check so that the import is only performed when using a version that utilized it.
* Fix initially made for https://github.com/lshqqytiger/stable-diffusion-webui-amdgpu-forge/issues/106 but it also affects this version.

## Checklist:

- [x] I have read [contributing wiki page](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing)
_(note, there is no dev branch)_
- [x] I have performed a self-review of my own code
- [x] My code follows the [style guidelines](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing#code-style)
- [x] My code passes [tests](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Tests)
